### PR TITLE
parse custom query options in an $expand clause

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -56,7 +56,8 @@ export namespace Query {
       if (!eq) return;
       index = eq;
 
-      while (value[index] !== 0x26 && index < value.length) index++;
+      // read to next ampersand, semicolon, or close paren
+      while (value[index] !== 0x26 && value[index] !== 0x3B && value[index] !== 0x29 && index < value.length) index++;
       if (index === eq) return;
 
       return Lexer.tokenize(value, start, index, { key: key.raw, value: Utils.stringify(value, eq, index) }, Lexer.TokenType.CustomQueryOption);
@@ -250,6 +251,7 @@ export namespace Query {
 
     export function expandRefOption(value: Utils.SourceArray, index: number): Lexer.Token {
         return Query.expandCountOption(value, index) ||
+            Query.customQueryOption(value, index) ||
             Query.orderby(value, index) ||
             Query.skip(value, index) ||
             Query.top(value, index) ||

--- a/test/parser.spec.js
+++ b/test/parser.spec.js
@@ -25,6 +25,26 @@ describe("Parser", () => {
     expect(ast.value.options[0].value.items[1].raw).to.equal("bar");
   });
 
+  it("should parse solo custom query option in $expand clause", () => {
+      var parser = new Parser();
+      var ast = parser.query("$expand=Items(skipToken=100)");
+      expect(ast.value.options[0].value.items[0].value.options[0].value.value).to.equal("100");
+  });
+
+  it("should parse custom query options in $expand clause", () => {
+      var parser = new Parser();
+      var ast = parser.query("$expand=Items($top=1;skipToken=100)");
+      expect(ast.value.options[0].value.items[0].value.options[0].value.raw).to.equal("1");
+      expect(ast.value.options[0].value.items[0].value.options[1].value.value).to.equal("100");
+  });
+
+  it("should parse custom query options in $expand clause when custom query option is first", () => {
+      var parser = new Parser();
+      var ast = parser.query("$expand=Items(skipToken=100;$top=1)");
+      expect(ast.value.options[0].value.items[0].value.options[0].value.value).to.equal("100");
+      expect(ast.value.options[0].value.items[0].value.options[1].value.raw).to.equal("1");
+  });
+
   it("should parse custom query options", () => {
     var parser = new Parser();
     var ast = parser.query("foo=123&bar=foobar");


### PR DESCRIPTION
the OData spec doesn't explicitly say if custom query options are allowed in an $expand clause, but I don't see any way to do pagination on a navigation property without them