### PR TITLE
Support for parsing ISO 8601 duration format with only time component

### DIFF
--- a/src/primitiveLiteral.ts
+++ b/src/primitiveLiteral.ts
@@ -187,7 +187,7 @@ export namespace PrimitiveLiteral {
         index++;
         let dayNext = Utils.required(value, index, Lexer.DIGIT, 1);
         if (dayNext === index && value[index + 1] !== 0x54) return;
-        index = dayNext;
+        if (dayNext != 0) index = dayNext;
         if (value[index] === 0x44) index++;
         let end = index;
         if (value[index] === 0x54) {

--- a/test/primitive-cases.json
+++ b/test/primitive-cases.json
@@ -326,6 +326,86 @@
     }
   },
   {
+    "-Name": "Duration 0 days",
+    "-Rule": "duration",
+    "Input": "duration'P0D'",
+    "result": {
+      "position": 0,
+      "type": "Literal",
+      "value": "Edm.Duration"
+    }
+  },
+  {
+    "-Name": "Duration 2-digit days",
+    "-Rule": "duration",
+    "Input": "duration'P10D'",
+    "result": {
+      "position": 0,
+      "type": "Literal",
+      "value": "Edm.Duration"
+    }
+  },
+  {
+    "-Name": "Duration days and hours",
+    "-Rule": "duration",
+    "Input": "duration'P10DT23H'",
+    "result": {
+      "position": 0,
+      "type": "Literal",
+      "value": "Edm.Duration"
+    }
+  },
+  {
+    "-Name": "Duration 0 days and 2 hours",
+    "-Rule": "duration",
+    "Input": "duration'P0DT2H'",
+    "result": {
+      "position": 0,
+      "type": "Literal",
+      "value": "Edm.Duration"
+    }
+  },
+  {
+    "-Name": "Duration hours no day component",
+    "-Rule": "duration",
+    "Input": "duration'PT2H'",
+    "result": {
+      "position": 0,
+      "type": "Literal",
+      "value": "Edm.Duration"
+    }
+  },
+  {
+    "-Name": "Duration minutes no day component",
+    "-Rule": "duration",
+    "Input": "duration'PT30M'",
+    "result": {
+      "position": 0,
+      "type": "Literal",
+      "value": "Edm.Duration"
+    }
+  },
+  {
+    "-Name": "Duration seconds no day component",
+    "-Rule": "duration",
+    "Input": "duration'PT5S'",
+    "result": {
+      "position": 0,
+      "type": "Literal",
+      "value": "Edm.Duration"
+    }
+  },
+  {
+    "-Name": "Duration seconds missing T",
+    "-Rule": "duration",
+    "Input": "duration'P5S'",
+    "result_error": {
+      "position": 0,
+      "type": "Literal",
+      "value": "Edm.Duration"
+    }
+  },
+  {
     "-Name": "Decimal: integer",
     "-Rule": "decimalValue",
     "Input": "-2",


### PR DESCRIPTION
Currently Duration parsing is failing if duration only contains a time component, not a date component. 

However, it is still a valid ISO 8601 duration if the string only has a time component, such as duration'PT2H'.

Modified primativeLiteral.ts to handle this case. 